### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Simply open userChrome.css in a text editor and change the values at the top of 
 ```CSS
 /* -------------------- 🎨 Customization 🎨 -------------------- */
     --tab-corner-rounding: 7px;
-    /* --menu-corner-rounding: 10px; */
-    /* --menu-item-height: 30px;     */
     --button-corner-rounding: 20px;
-    --animation-speed: 0.4s;
+    /* --menu-item-height: 35px;     */
+    --animation-speed: 0.4s
+    /* --menu-corner-rounding: 11px; */
 ```
 ![](https://coekuss.com/quietfox/quietfox70/fluid2.gif)
 
@@ -34,10 +34,10 @@ Simply open userChrome.css in a text editor and change the values at the top of 
 ```CSS
 /* -------------------- 🎨 Customization 🎨 -------------------- */
     --tab-corner-rounding: 0px;
-    /* --menu-corner-rounding: 10px; */
-    /* --menu-item-height: 30px;     */
     --button-corner-rounding: 0px;
-    --animation-speed: 0.0s;
+    /* --menu-item-height: 35px;     */
+    --animation-speed: 0.0s
+    /* --menu-corner-rounding: 11px; */
 ```
 ![](https://coekuss.com/quietfox/quietfox70/snappy2.gif)
 
@@ -45,10 +45,10 @@ Simply open userChrome.css in a text editor and change the values at the top of 
 ```CSS
 /* -------------------- 🎨 Customization 🎨 -------------------- */
     /* --tab-corner-rounding: 7px;     */
-    --menu-corner-rounding: 10px;
-    --menu-item-height: 30px;
     /* --button-corner-rounding: 20px; */
+    --menu-item-height: 30px;
     /* --animation-speed: 0.4s;        */
+    --menu-corner-rounding: 10px;
 ```
 
 <p align="center">
@@ -60,10 +60,10 @@ Simply open userChrome.css in a text editor and change the values at the top of 
 ```CSS
 /* -------------------- 🎨 Customization 🎨 -------------------- */
     /* --tab-corner-rounding: 7px;     */
-    --menu-corner-rounding: 0px;
-    --menu-item-height: 25px;
     /* --button-corner-rounding: 20px; */
+    --menu-item-height: 25px;
     /* --animation-speed: 0.4s;        */
+    --menu-corner-rounding: 0px;
 ```
 <p align="center">
     <img src="https://coekuss.com/quietfox/short_sharp.png">


### PR DESCRIPTION
Updated the README file to better represent the actual userChrome.css file which is distributed in the releases section: 
Most of the values are switched around and the default values for `--menu-item-height: 35px;` and `--menu-corner-rounding: 11px;` were changed from 30 to 35 and 10 to 11 respectively, following the defaults given in the latest release. In the second set of examples, these values are reverted back to 30 and 11 to make sure the accompanying GIF is still accurate. The `--toolbarbutton-hover-background: rgba(127, 127, 127, 0.5);` value has been left out as it isn't touched in any of the examples. However, if someone were willing to redo the GIFs/examples, this value could be showcased as well.

The goal here is to make it a bit easier for new users to change the correct values in their userChrome.css file as they can now do a side-by-side comparison of the README and their own userChrome.css file.