### PR TITLE
Add White Mode (also readme for important info)

### DIFF
--- a/whitemode/quietContexts.css
+++ b/whitemode/quietContexts.css
@@ -1,0 +1,170 @@
+:root[lwt-popup-brighttext] toolbaritem[cui-areatype="panel"] > .webextension-browser-action {
+  padding-top: 25px !important;
+  padding-bottom: 25px !important;
+}
+panelview#unified-extension-view.cui-widget-panelview{
+    height: 486px !important;
+}
+.subviewbutton[disabled="true"] {
+  padding-top: 22px !important;
+  padding-bottom: 23px !important;
+}
+#appMenu-popup panelview{
+    width: 25em !important;
+}
+/* New Icons to main menu */
+#appMenu-fxa-status2[fxastatus] > toolbarbutton::before,
+#appMenu-protonMainView > .panel-subview-body > toolbarbutton > image{
+  fill: currentColor;
+  -moz-context-properties: fill;
+  margin-inline: 0 8px !important;
+}
+#appMenu-new-tab-button2{ 
+    list-style-image: url("chrome://browser/skin/new-tab.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-new-tab-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-new-window-button2{ 
+    list-style-image: url("chrome://browser/skin/window.svg"); 
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-new-window-button2 > .toolbarbutton-text{
+     margin-left: 8px !important;
+}
+#appMenu-new-private-window-button2{ 
+    list-style-image: url("chrome://browser/skin/privateBrowsing.svg"); 
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-new-private-window-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-bookmarks-button{ 
+    list-style-image: url("chrome://browser/skin/bookmark-star-on-tray.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-bookmarks-button > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-history-button{ 
+    list-style-image: url("chrome://browser/skin/history.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-history-button > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-downloads-button{ 
+    list-style-image: url("chrome://browser/skin/downloads/downloads.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color); 
+}
+#appMenu-downloads-button > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+
+#appMenu-passwords-button{ 
+    list-style-image: url("chrome://browser/skin/login.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-passwords-button > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-extensions-themes-button{ 
+    list-style-image: url("chrome://mozapps/skin/extensions/extension.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color); 
+}
+#appMenu-extensions-themes-button > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-print-button2{ 
+    list-style-image: url("chrome://global/skin/icons/print.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-print-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-save-file-button2{ 
+    list-style-image: url("chrome://browser/skin/save.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-save-file-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-find-button2{ 
+    list-style-image: url("chrome://global/skin/icons/search-glass.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-find-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-settings-button{ 
+    list-style-image: url("chrome://global/skin/icons/settings.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color); 
+}
+#appMenu-settings-button > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-more-button2{ 
+    list-style-image: url("chrome://global/skin/icons/developer.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-more-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-help-button2{ 
+    list-style-image: url("chrome://global/skin/icons/info.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-help-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-quit-button2{ 
+    list-style-image: url("chrome://devtools/skin/images/search-clear.svg");
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-quit-button2 > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-translate-button{
+    -moz-context-properties: fill;
+    fill:var(--icons-burger-menu-fill-color);
+}
+#appMenu-translate-button > .toolbarbutton-text{
+    margin-left: 8px !important;
+}
+#appMenu-fxa-status2[fxastatus] > toolbarbutton::before{
+  display: -moz-box;
+  content: "";
+  width: 16px;
+  height: 16px;
+  background-image: var(--avatar-image-url)
+}
+#appMenu-protonMainView > .panel-subview-body::after{
+  content: "";
+  display: -moz-box;
+  border-bottom: 1px solid var(--panel-separator-color);
+  margin: var(--panel-separator-margin);
+}
+
+#appMenu-find-button2 ~ *{
+  -moz-box-ordinal-group: 2;
+}
+
+.protections-popup-tp-switch{
+    max-height: 14px !important;
+}

--- a/whitemode/quietExtensions.css
+++ b/whitemode/quietExtensions.css
@@ -1,0 +1,103 @@
+vbox#unified-extensions-area {
+  margin-left: -5px;
+}
+vbox#unified-extensions-area > toolbaritem > .unified-extensions-item-action-button{
+    height: 63px !important;
+}
+vbox#unified-extensions-area .unified-extensions-item-action-button > .toolbarbutton-badge-stack > image{
+   position: relative;
+   right: 10% !important;
+}
+vbox#overflowed-extensions-list {
+  margin-left: -5px;
+}
+vbox#overflowed-extensions-list > toolbaritem > .unified-extensions-item-action-button{
+    height: 63px !important;
+}
+vbox#overflowed-extensions-list .unified-extensions-item-action-button > .toolbarbutton-badge-stack > image{
+   position: relative;
+   right: 10% !important;
+}
+vbox.unified-extensions-list > .toolbaritem-combined-buttons vbox {
+    margin-left: -5px !important;
+}
+#unified-extensions-view{
+    width: 355px !important;
+}
+
+#unified-extensions-view:hover 
+.unified-extensions-item-menu-button.subviewbutton{ 
+    visibility: visible !important;
+    transition: var(--hovering-speed) !important;
+    -moz-margin-end: initial !important;
+    -moz-margin-start: -7px !important;
+}
+#unified-extensions-panel toolbaritem.unified-extensions-item {
+  width:342px !important;
+  height: 75px;
+  margin-block: initial !important;
+}
+#unified-extensions-panel toolbarbutton.unified-extensions-item-action-button > image{
+    position: relative;
+    right: 1% !important;
+}
+.unified-extensions-item-menu-button.subviewbutton > .toolbarbutton-icon{
+    margin-inline-start: initial !important;
+}
+.unified-extensions-item-menu-button.subviewbutton{
+ width: 35px !important;   
+}
+.unified-extensions-item-menu-button.subviewbutton .toolbarbutton-icon{
+    margin-left: -7px !important;
+}
+/*  Extension menu option button mod */
+#unified-extensions-view .unified-extensions-item-menu-button.subviewbutton{
+    visibility: hidden !important;
+    transition: all var(--animation-speed) !important;
+    -moz-margin-end: -3.2em !important;
+}
+
+
+#unified-extensions-view .unified-extensions-item-name, 
+#unified-extensions-view .unified-extensions-item-message {
+    padding-inline-start: 0.5em !important;
+    width: 21em !important;
+}
+.unified-extensions-item-menu-button.subviewbutton{
+    padding-inline-end: revert !important;
+}
+.unified-extensions-list .toolbaritem-combined-buttons.unified-extensions-item {
+  margin: 3px !important;
+  height: 63px !important;
+  width: 342px !important;
+}
+#unified-extensions-button[open]{
+  background-color: var(--toolbarbutton-focus-background) !important;
+}
+#unified-extensions-button[open]:hover{
+  background-color:var(--toolbarbutton-hover-mozilla-button) !important;
+}
+.unified-extensions-item-action-button[open]{
+    background: var(--toolbarbutton-hover-mozilla-button) !important;
+}
+.panel-subview-body > .identity-color-turquoise > .toolbarbutton-icon{
+    fill:var(--identity-tab-color) !important;
+}
+.panel-subview-body > .identity-color-green > .toolbarbutton-icon{
+    fill:var(--identity-tab-color) !important;
+}
+.panel-subview-body > .identity-color-orange > .toolbarbutton-icon{
+    fill:var(--identity-tab-color) !important;
+}
+.panel-subview-body > .identity-color-pink > .toolbarbutton-icon{
+    fill:var(--identity-tab-color) !important;
+}
+.panel-subview-body > .identity-color-purple > .toolbarbutton-icon{
+    fill:var(--identity-tab-color) !important;
+}
+.panel-subview-body > .identity-color-red > .toolbarbutton-icon{
+    fill:var(--identity-tab-color) !important;
+}
+.panel-subview-body > .identity-color-yellow > .toolbarbutton-icon{
+    fill:var(--identity-tab-color) !important;
+}

--- a/whitemode/quietMenus.css
+++ b/whitemode/quietMenus.css
@@ -1,0 +1,341 @@
+#context-navigation,
+#context-sep-navigation,
+#context-
+link,
+#context-viewinfo,
+#context-viewpartialsource-selection,
+#inspect-separator,
+#context-savelink,
+#context-sendimage,
+#context-setDesktopBackground,
+#context_reloadTab,
+#context_moveTabOptions,
+#context_bookmarkTab,
+.bookmarks-actions-menuseparator,
+.openintabs-menuitem {
+    display: none !important;
+}
+menupopup,
+menupopup menuitem,
+menupopup menu,
+menupopup menuseparator:hover{
+    border-radius:var(--menu-corner-rounding);
+    transition: var(--animation-speed) !important;
+}
+menupopup,
+menuitem
+menucaption{
+    border-radius:19px!important;
+}
+menuitem[disabled="true"], menuitem[disabled="true"] > .menu-text {
+	color: #838584 !important;
+}
+menuitem > .menu-text{
+    color: black !important;
+}
+
+
+
+menupopup,
+menupopup menuitem,
+menupopup menu,
+menupopup menuseparator {
+	-moz-appearance: none !important;
+}
+menupopup:not(#BMB_bookmarksPopup) {
+    border:0 !important;
+    background-color: var(--transparent-color) !important;
+}
+
+menu[open] menupopup:not(#BMB_bookmarksPopup) {
+	margin: -7px -0px !important;
+}
+
+
+#BMB_bookmarksPopup menu[open] menupopup {
+    transform: translateY(4px) !important;
+}
+menupopup#contentAreaContextMenu menu:hover,
+menupopup#contentAreaContextMenu menuitem:hover{
+    border-radius:var(--menu-corner-rounding) !important;
+    margin-left:5px;
+    margin-right:-30px;
+}
+menupopup menuseparator
+{
+	margin-top: 5px !important;
+    margin-bottom: 5px !important;
+	padding: 0px !important;
+    border-bottom: none !important;
+	opacity: 0.5 !important;
+}
+.menupopup-arrowscrollbox {
+    background: Menu !important; /* fall back if adaptable colors are removed */  
+}
+
+.menupopup-arrowscrollbox:not(.in-bookmarks-menu) {
+	padding: 6px 0 !important;
+}
+#history-panel menupopup{
+  color: black !important;
+}
+#history-panel menupopup menuitem{
+    color: white !important;
+}
+#history-panel #sidebar-search-container {
+  height: 45px !important;
+}
+#bookmarksPanel menupopup menuitem{
+    color: white !important;
+}
+#bookmarksPanel search-textbox{
+    height: 30px !important;
+}
+#bookmarksMenu menupopup{
+    color:black !important;
+}
+.menuitem-iconic[data-usercontextid]{
+    fill:var(--identity-tab-color) !important;
+}
+box.panel-viewstack{
+    max-height: 100vh !important;
+}
+
+/*For translate button on menu burger*/
+#appMenu-translate-button {
+  list-style-image: url(chrome://browser/skin/translations.svg);
+}
+
+.panel-arrowcontent {
+    padding-top: 0px !important;
+    border: none !important;
+}
+.menupopup-arrowscrollbox:not(.in-bookmarks-menu) {
+    border-radius:var(--menu-corner-rounding) !important;
+    box-shadow: 0px 2px -3px -4px black !important;
+}
+
+
+.panel-arrowcontainer .panel-arrowcontent, .menupopup-arrowscrollbox, hbox[flex="1"][part="innerbox"] {
+    border-radius: var(--menu-corner-rounding) !important;
+}
+
+.in-bookmarks-menu {
+    padding-bottom: 5px !important;
+    padding-top: 5px !important;
+}
+
+menu,
+menuitem, 
+menucaption {
+    -moz-appearance: none !important;
+    height: var(--menu-item-height) !important;
+    margin-left:15px !important;
+    margin-right:12px !important;
+    border-radius: var(--menu-corner-rounding) !important;
+}
+
+
+menu,
+menuitem, 
+menucaption {
+    padding-left: 5px !important;
+    padding-right: 5px !important;
+}
+menu:not(.subviewbutton) > .menu-right  {
+    margin-top: 2px !important;
+    margin-right: 0px !important;
+    width: 0px !important;
+}
+menuitem.menuitem-iconic.bookmark-item.menuitem-iconic.menuitem-with-favicon:hover{
+    border-radius: var(--menu-corner-rounding) !important;
+}
+
+menu:not(.subviewbutton) > .menu-right image {
+    margin-right: -5px !important;
+    margin-top: -2px !important;
+    border: 8px solid var(--toolbar-color) !important;
+    border-top-color: var(--transparent-color) !important;
+    border-right-color: var(--transparent-color) !important;
+    border-bottom-color: var(--transparent-color) !important;
+}
+panelview toolbarbutton:not(#fxa-manage-account-button) {
+    height: var(--menu-item-height) !important;
+}
+
+#BMB_bookmarksPopup .menu-right {
+    height: 23px !important;
+}
+image#picture-in-picture-button-icon{
+    margin-top: -2px !important;
+    margin-left: 1px !important;
+}
+hbox#picture-in-picture-button.urlbar-page-action{
+    width: 35px !important;
+    height: 35px !important;
+    border-radius: var(--button-corner-rounding) !important;
+}
+hbox#picture-in-picture-button.urlbar-page-action:hover{
+    width: 35px !important;
+    height: 35px !important;
+    border-radius: var(--button-corner-rounding) !important;
+    transition: all var(--hovering-speed) !important;
+}
+hbox#translations-button.urlbar-page-action{
+    width: 35px !important;
+    height: 35px !important;
+    border-radius: var(--button-corner-rounding) !important;
+}
+hbox#translations-button.urlbar-page-action:hover{
+    transition: all var(--hovering-speed) !important;
+    border-radius: var(--button-corner-rounding) !important;
+}
+hbox#pageAction-urlbar-_testpilot-containers.urlbar-page-action{
+    width: 35px !important;
+    height: 35px !important;
+    border-radius: var(--button-corner-rounding) !important;
+}
+hbox#pageAction-urlbar-_testpilot-containers.urlbar-page-action:hover{
+    transition: all var(--hovering-speed) !important;
+    border-radius: var(--button-corner-rounding) !important;
+}
+hbox.menu-right > image{
+    margin-left: -9px !important;
+}
+
+#sidebar-switcher-bookmarks, #customization-uidensity-menuitem-compact {
+    margin-top: 5px !important;
+}
+
+#customization-lwtheme-menu-header {
+    margin-top: 0px !important;
+}
+@-moz-document url("chrome://global/content/alerts/alert.xhtml") {
+  #alertBox{
+    border-radius: var(--menu-corner-rounding) !important;
+    background-color: rgb(58,67,82) !important;
+    color: white !important;
+  }
+  #alertSourceLabel{
+    color: white !important;
+  }
+  #alertBox, image{
+        border-radius: var(--button-corner-rounding) !important;
+  }
+  #alertSettings{
+        color:white !important;
+  }
+    menupopup{
+       color:rgb(58,67,82) !important;
+    }
+    menupopup,
+    menuitem#openSettingsMenuItem{
+        color: white !important;
+    }
+    menupopup,
+    menuitem#disableForOriginMenuItem{
+       color: white !important;
+    }
+    menupopup,
+    menuitem#doNotDisturbMenuItem{
+        color: white !important;
+    }
+}
+#ContentSelectDropdown > menupopup > :not([_moz-menuactive="true"]) {
+    background:transparent !important;
+}
+@media (-moz-os-version: windows-win7), (-moz-os-version: windows-win8), (-moz-os-version: windows-win10) {
+    .bookmark-item .scrollbutton-up {
+        margin-top: -3px !important;
+    }
+
+    .bookmark-item .scrollbutton-up > .toolbarbutton-icon {
+        margin-top: -2px !important;
+        border: 6px solid MenuText !important;
+        border-top-color: var(--transparent-color) !important;
+        border-right-color: var(--transparent-color) !important;
+        border-left-color: var(--transparent-color) !important;
+    }
+
+    .bookmark-item .scrollbutton-down {
+        margin-bottom: -3px !important;
+    }
+
+    .bookmark-item .scrollbutton-down > .toolbarbutton-icon {
+        margin-bottom: -2px !important;
+        border: 6px solid MenuText !important;
+        border-bottom-color: var(--transparent-color) !important;
+        border-right-color: var(--transparent-color) !important;
+        border-left-color: var(--transparent-color) !important;
+    }
+    
+    menu,
+    menuitem, 
+    menucaption {
+        padding-left: 5px !important;
+        padding-right: 5px !important;
+    }
+    
+    menu:not(.subviewbutton) > .menu-right  {
+        margin-right: 0px !important;
+        padding-left: 0px !important;
+    }
+    
+    .in-bookmarks-menu {
+        padding-bottom: 5px !important;
+        padding-top: 1px !important;
+    }
+    
+    #BMB_bookmarksPopup menu menupopup {
+        transform: translateY(-1px) !important;
+    }
+}
+@media not (-moz-os-version: windows-win10)  {
+    @media not (-moz-os-version: windows-win8) {
+       @media not (-moz-os-version: windows-win7)  {
+            hbox[flex="1"][part="innerbox"] {
+                box-shadow: 0px 2px 12px -6px black !important;
+            }
+
+            .menu-iconic-left {
+                margin: 0px 6px !important;
+            }
+           
+           #BMB_bookmarksPopup menu[open] menupopup {
+                transform: translateY(1px) !important;
+            }
+        }
+    }
+}
+
+menu,
+menuitem,
+menucaption {
+    color: var(--toolbar-color) !important;
+}
+
+.menupopup-arrowscrollbox {
+    background-color: var(--toolbar-bgcolor, Menu) !important;
+}
+
+menu[_moz-menuactive="true"]:not([disabled="true"]), 
+menuitem[_moz-menuactive="true"]:not([disabled="true"]), 
+menucaption[_moz-menuactive="true"]:not([disabled="true"]) {
+    background-color: var(--toolbarbutton-hover-background, rgba(127,127,127,0.5)) !important;
+}
+@media (-moz-windows-non-native-menus) {
+  menupopup {
+    --panel-color: white !important;
+    --panel-border-radius: 4px;
+    --panel-padding: 4px 0;
+    --panel-border-color: var(--menu-border-color);
+    --panel-background: black !important;
+    --nested-margin: -6px;
+  }
+}
+
+menu[disabled="true"], 
+menuitem[disabled="true"], 
+menucaption[disabled="true"] {
+    color: var(--toolbarbutton-hover-background, rgba(127,127,127,0.5)) !important;
+}

--- a/whitemode/quietTab.css
+++ b/whitemode/quietTab.css
@@ -1,0 +1,160 @@
+tab[visuallyselected] .tab-background::before,
+tab[visuallyselected] .tab-background::after {
+    content: "" !important;
+    display: inline !important;
+    position: absolute !important;
+    width: var(--tab-corner-rounding) !important;
+    height: var(--tab-corner-rounding) !important;
+    bottom: -1px !important;
+    pointer-events: none !important;
+    background-color: var(--transparent-color) !important;
+    transition: var(--animation-speed) !important;
+}
+#TabsToolbar #firefox-view-button[open] > .toolbarbutton-icon:-moz-lwtheme, .tab-background[selected]:-moz-lwtheme {
+    outline:none !important;
+}
+:root {
+  &[lwtheme] {
+    --tab-selected-outline-color: none !important;
+  }
+}
+#tabbrowser-arrowscrollbox-periphery {
+  margin-left: 6px;
+}
+tab[visuallyselected] .tab-background::before {
+    border-bottom-right-radius: var(--tab-corner-rounding) !important;
+    transform: translateX(calc(-1 * var(--tab-corner-rounding))) !important;
+    box-shadow: 0.5px 1px 0.5px 0.5px var(--toolbar-bgcolor) !important;
+    transition: var(--animation-speed) !important;
+    border: var(--tab-corner-rounding) !important;
+}
+
+tab[visuallyselected] .tab-background::after {
+    border-bottom-left-radius: var(--tab-corner-rounding) !important;
+    right: 0px !important;
+    transform: translateX(calc(var(--tab-corner-rounding) + 1px)) !important;
+    box-shadow: 0px 4px 0px 0px var(--toolbar-bgcolor) !important;
+    transition: var(--animation-speed) !important;
+}
+.titlebar-spacer[type="pre-tabs"] {
+    border-inline-end: 0px !important;
+    width: 0px !important;
+}
+
+scrollbox[part="scrollbox"][flex="1"][orient="horizontal"] {
+    padding-left: 12px !important;
+}
+
+
+[sizemode="maximized"] [first-visible-tab] {
+    margin-left: -12px !important;
+}
+
+[sizemode="maximized"] [first-visible-tab] stack {
+    margin-left: 12px !important;
+}
+
+.tab-background, .tab-loading-burst  {
+    border-radius: var(--tab-corner-rounding) var(--tab-corner-rounding) 0px 0px !important;
+    margin: -1px !important;
+}
+
+tab:not(:active) .tab-background {
+    transition: background-color var(--animation-speed) !important;
+}
+
+
+:root[uidensity="compact"] {
+    --tab-min-height: 31px !important;
+}
+
+tab:not([selected]):hover .tab-background {
+    background-color: var(--toolbarbutton-hover-background) !important;
+}
+
+tab {
+    min-width: 1px !important;
+    clip-width: 1px !important;
+    padding-bottom: 1px !important!
+}
+tab[beforehovered],
+tab:not([selected]):hover{
+    border: none !important;
+}
+
+tab[beforeselected-visible]{
+    border:none !important;
+}
+
+.tab-line {
+    display: none !important;
+}
+
+tab:not([beforeselected-visible])::after {
+    margin-top: 4px !important;
+    margin-bottom: 4px !important;
+    transition: border-color var(--animation-speed), margin-top var(--animation-speed) !important;
+    color: ;
+}
+tab[beforehovered]::after,
+tab:hover::after {
+    border-color: var(--transparent-color) !important;
+    margin-top: 20px !important;
+}
+
+#navigator-toolbox {
+    --tabs-border-color: var(--transparent-color) !important;
+}
+
+tab[visuallyselected] .tab-background {
+        box-shadow: 0px 3px 12px -5px black !important;
+}
+[last-visible-tab] {
+    margin-right: calc(var(--tab-corner-rounding)) !important; /* fix unexpected tab overflow */
+}
+.tab-context-line {
+    transform:scaleX(0.9);
+    transition:var(--container-context-line-speed-animation) !important;
+    margin: 1.2px var(--inline-tab-padding) 0 !important;
+}
+.tabbrowser-tab:is([visuallyselected], [multiselected]){
+    color:transparent !important;
+}
+.tab-content {
+    color: black !important;
+}
+tab:not([selected]):hover .tab-context-line{
+    transform:scaleX(1.08);
+    -moz-transition: 0.7s !important;
+    overflow-x:: hidden !important;
+    margin: 1.2px var(--inline-tab-padding) 0 !important;
+}
+tab[visuallyselected] .tab-context-line{
+    transform:scaleX(1.08);
+    margin: 1.2px var(--inline-tab-padding) 0 !important;
+    color: red !important;
+}
+#TabsToolbar{
+   --lwt-tab-line-color: var(--transparent-color) !important;
+}
+.tab-close-button {
+    transition: fill-opacity var(--animation-speed) !important;
+}
+:root[uidensity="touch"] tab {
+    height: 40px !important;
+}
+:root[uidensity="touch"] #tabs-newtab-button {
+    margin-left: -5px !important;
+    margin-bottom: 2px !important;
+    padding-right: 3px !important;
+    padding-left: 3px !important;
+    padding-bottom: 1px !important;
+}
+.tab-background:is([selected], [multiselected]):-moz-lwtheme {
+  border: hidden !important;
+}
+.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-context-line {
+  background: var(--identity-icon-color) !important;
+  height: 3.5px !important;
+  border-radius: 2px !important;
+}

--- a/whitemode/quietUrlbar.css
+++ b/whitemode/quietUrlbar.css
@@ -1,0 +1,948 @@
+.toolbarbutton-icon, .toolbarbutton-badge-stack {
+    background-color: var(--transparent-color) !important;
+}
+#forward-button[open='true']{
+    background: var(--toolbarbutton-hover-mozilla-button) !important;
+}
+#back-button[open] > .toolbarbutton-icon{
+  height: 36px !important;
+}
+.toolbarbutton-1[open='true']{
+    background: var(--toolbarbutton-focus-background) !important;
+}
+.bookmark-item .toolbarbutton-icon {
+  border-radius:var(--icon-border-rounding) !important;
+}
+.toolbarbutton-icon, .toolbarbutton-badge-stack {
+    background-color: var(--transparent-color) !important;
+}
+
+#tabbrowser-arrowscrollbox-periphery {
+  margin-left: 6px;
+}
+
+toolbarbutton:not(#back-button)[open], .toolbarbutton-1:not(#back-button)[open] {
+    background-color: var(--toolbarbutton-focus-background);
+}
+
+.tabbrowser-tab:is([visuallyselected], [multiselected]){
+    
+}
+#nav-bar .toolbarbutton-1 {
+    margin-right: 2px !important;
+}
+
+.close-icon:not(.tab-close-button):hover {
+    /*fill-opacity: 0.0 !important;*/
+}
+
+toolbarbutton:not(#back-button):not(#forward-button):not([disabled]):not([open]):hover,
+.toolbarbutton-1:not(#back-button):not(#forward-button):not([disabled]):not([open]):hover {
+    border-radius: var(--button-corner-rounding) !important;
+    background-color: var(--toolbarbutton-hover-background) !important;
+    transition: all var(--animation-speed) !important;
+}
+.tab-close-button {
+    transition: fill-opacity var(--animation-speed) !important;
+}
+.findbar-textbox:focus {
+    border: 1px solid grey !important;
+}
+
+#BMB_bookmarksShowAll {
+    display: none !important;
+}
+.titlebar-button{
+    border-radius: var(--button-corner-rounding) !important;
+    transition: all var(--hovering-speed) !important;
+}
+toolbarbutton.bookmark-item[dragover="true"][open="true"]{
+    background:var(--toolbarbutton-dragover) !important;
+    color:white !important;
+}
+toolbarbutton.bookmark-item{
+    fill:white !important;
+}
+.menu-iconic-icon{
+    border-radius: 11px !important;
+}
+.toolbar-menupopup :is(menu, menuitem), .subview-subheader, panelview .toolbarbutton-1, .subviewbutton, .widget-overflow-list .toolbarbutton-1{
+ margin-left:10px !important;
+ margin-right: 10px !important;
+}/* touch and normal density buttons */
+
+:root:not([uidensity="compact"]) #back-button > .toolbarbutton-icon {
+    background-color: var(--transparent-color) !important;
+    border-color: var(--toolbarbutton-hover-background) !important;
+    border-radius: var(--button-corner-rounding) !important;
+    width:38px !important;
+    transition: background-color var(--animation-speed) !important;
+}
+
+:root:not([uidensity="compact"]) #back-button:not([disabled]):not([open]):hover > .toolbarbutton-icon {
+    background-color: var(--toolbarbutton-hover-background) !important;
+    box-shadow: none !important;
+    height: 36px !important;
+}
+:root:not([uidensity="compact"]) #forward-button:not([disabled]):not([open]):hover > .toolbarbutton-icon{
+    background-color: var(--toolbarbutton-hover-background) !important;
+    box-shadow: none !important;
+    height: 32px !important;
+    transform: scale(1.1) !important;
+    border-radius: 6px !important;
+}
+
+:root:not([uidensity="compact"]) #back-button:not([disabled]):not([open]):active > .toolbarbutton-icon {
+    background-color: var(--toolbarbutton-focus-background) !important;
+    box-shadow: none !important;
+}
+
+:root:not([uidensity="compact"]) toolbarbutton:not(#back-button):not([disabled]):not([open]):active,
+.toolbarbutton-1:not(#back-button):not([disabled]):not([open]):active {
+    background-color: var(--toolbarbutton-focus-background) !important;
+}
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #forward-button-button{
+    margin-top: -1px !important;
+  margin-bottom: -1px !important;
+}
+
+
+:root:not([uidensity="compact"]) #back-button[open] > .toolbarbutton-icon {
+    background-color: var(--toolbarbutton-focus-background) !important;
+}
+
+:root:not([uidensity="compact"]) #PersonalToolbar { /* bookmark bar */
+    height: 30px !important; 
+}
+/* normal density buttons */
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #nav-bar .toolbarbutton-1:not(#back-button)  {
+    margin-top: 4px !important;
+    margin-bottom: 4px !important;
+    margin-left: 0px !important;
+    margin-right: 0px !important;
+    padding-left: 3px !important;
+    padding-right: 3px !important;
+}
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #nav-bar .toolbarbutton-1:is(#back-button){
+    margin-top: 4px !important;
+    margin-bottom: 4px !important;
+    margin-left: 4px !important;
+    margin-right: 0px !important;
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #nav-bar .toolbarbutton-1:not(#back-button) image  {
+    margin-bottom: 1px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #back-button {
+    margin-top: -1px !important;
+    margin-bottom: -1px !important;
+}
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #identity-icon, 
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #tracking-protection-icon-box {
+    margin-left: 2px !important;
+    margin-right: 2px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #urlbar {
+    height: 36px !important;
+    margin-top: 0px !important;
+    margin-bottom: 0px !important;
+    padding-top: 0px !important;
+    padding-bottom: 0px !important;
+}
+
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) .urlbar-icon:not(#pocket-button) {
+    width: 34px !important;
+    height: 36px !important;
+    padding: 8px !important;
+}
+
+
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #pocket-button {
+    width: 32px !important;
+    height: 36px !important;
+    padding: 8px 8px 6px 8px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #contextual-feature-recommendation {
+    width: 32px !important;
+    height: 32px !important;
+    padding: 2px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #PanelUI-button {
+    padding-right: 5px !important;
+    padding-left: 5px !important;
+    margin-left: 5px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #library-animatable-box {
+    margin-top: 4px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #tabs-newtab-button {
+    margin-left: -5px !important;
+    padding-left: 2px !important;
+    margin-bottom: 1px !important;
+    padding-bottom: 1px !important;
+}
+
+:root:not([uidensity="touch"]):not([uidensity="compact"]) #PersonalToolbar {
+    margin-top: -2px !important;
+}
+
+:root[uidensity="compact"] #nav-bar .toolbarbutton-1  {
+    margin-top: 4px !important;
+    margin-bottom: 4px !important;
+    padding: 0px 0px 0px 0px !important;
+}
+
+
+
+
+:root[uidensity="compact"] #nav-bar toolbaritem[animate] box {
+    margin-top: 1px !important;
+}
+
+:root[uidensity="compact"] #back-button {
+    margin-left: 3px !important;
+}
+
+:root[uidensity="compact"] #back-button[open] {
+    background-color: var(--toolbarbutton-focus-background) !important; 
+}
+
+
+:root[uidensity="compact"] #back-button:not([disabled]):not([open]):hover {
+    background-color: var(--toolbarbutton-hover-background) !important;
+}
+:root[uidensity="compact"] #back-button:not([disabled]):not([open]):active {
+    background-color: var(--toolbarbutton-focus-background) !important;
+}
+
+:root[uidensity="compact"] #identity-box,
+:root[uidensity="compact"] #tracking-protection-icon-container {
+    min-width: 2px !important;
+    padding-left: 6px !important;
+    padding-right: 6px !important;
+}
+
+
+:root[uidensity="compact"] #urlbar {
+    height: 30px !important;
+    margin-top: 0px !important;
+    margin-bottom: 0px !important;
+    padding-bottom: 0px !important;
+}
+
+
+
+:root[uidensity="compact"] .urlbar-icon:not(#pocket-button) {
+    width: 28px !important;
+    height: 30px !important;
+    padding: 6px !important;
+}
+
+:root[uidensity="compact"] #pocket-button {
+    width: 28px !important;
+    height: 40px !important;
+    padding: 7px 6px 5px 6px !important;
+}
+
+:root[uidensity="compact"] #contextual-feature-recommendation {
+    width: 32px !important;
+    height: 32px !important;
+    padding: 2px !important;
+}
+
+:root[uidensity="compact"] #PersonalToolbar {
+   height: 25px !important;
+    margin-top: -3px !important;
+}
+
+:root[uidensity="compact"] #library-animatable-box {
+    margin-top: 5px !important;
+}
+
+:root[uidensity="compact"] #tabs-newtab-button {
+    margin-left: -5px !important;
+    margin-bottom: 1px !important;
+    padding-bottom: 1px !important;
+}
+
+
+/* touch density buttons */
+
+:root[uidensity="touch"] #nav-bar .toolbarbutton-1:not(#back-button)  {
+    margin-top: 4px !important;
+    margin-bottom: 4px !important;
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+}
+
+#placesToolbar #back-button image{
+    width:16px !important;
+    height: 16px !important;
+}
+#placesToolbar #back-button:not([disabled]):hover{
+    background-color: var(--toolbarbutton-hover-background) !important;
+}
+#placesToolbar #back-button image{
+    background-color:initial !important;
+}
+
+:root[uidensity="touch"] #stop-reload-button[animate] .toolbarbutton-animatable-image {
+    margin-top: 2px !important;
+}
+
+:root[uidensity="touch"] #identity-box,
+:root[uidensity="touch"] #tracking-protection-icon-container {
+    padding-left: 9px !important;
+    padding-right: 9px !important;
+}
+
+
+:root[uidensity="touch"] #urlbar {
+    height: 36px !important;
+    margin-top: 0px !important;
+    margin-bottom: 0px !important;
+}
+
+:root[uidensity="touch"] #nav-bar{
+    padding-top: 0px !important;
+}
+
+:root[uidensity="touch"] .urlbar-icon:not(#pocket-button) {
+    width: 34px !important;
+    height: 36px !important;
+    padding: 9px !important;
+}
+
+:root[uidensity="touch"] #pocket-button {
+    width: 34px !important;
+    height: 36px !important;
+    padding: 10px 7px 8px 7px !important;
+}
+
+:root[uidensity="touch"] #contextual-feature-recommendation {
+    width: 32px !important;
+    height: 33px !important;
+    padding: 2px !important;
+}
+
+:root[uidensity="touch"] #PanelUI-button {
+    padding-left: 5px !important;
+    padding-right: 5px !important;
+}
+
+:root[uidensity="touch"] tab {
+    height: 40px !important;
+}
+
+:root[uidensity="touch"] #library-animatable-box {
+    margin-top: 7px !important;
+}
+
+:root[uidensity="touch"] #tabs-newtab-button {
+    margin-left: -5px !important;
+    margin-bottom: 2px !important;
+    padding-right: 3px !important;
+    padding-left: 3px !important;
+    padding-bottom: 1px !important;
+}
+.tab-background:is([selected], [multiselected]):-moz-lwtheme {
+  border: hidden !important;
+}
+
+:root[uidensity="touch"] #PersonalToolbar {
+   height: 35px !important;
+   margin-top: -3px !important;
+}
+
+.urlbar-input-box,
+#identity-box, 
+#tracking-protection-icon-container,
+.urlbar-history-dropmarker, 
+.urlbar-page-action,
+#reader-mode-button-icon, 
+[anonid=urlbar-go-button],
+.toolbarbutton-1 > stack,
+toolbarbutton:not(.titlebar-button):not([class^="findbar-find"]):not([class^="scrollbutton"]),
+.close-icon
+{
+    border-radius: var(--button-corner-rounding) !important;
+}
+
+.findbar-find-next {
+    border-radius: 0px var(--button-corner-rounding) var(--button-corner-rounding) 0px !important;
+}
+
+.findbar-textbox {
+    border-radius: var(--button-corner-rounding) var(--button-corner-rounding) var(--button-corner-rounding) var(--button-corner-rounding) !important;
+}
+#identity-box #identity-permission-box:hover{
+    border-radius:var(--button-corner-rounding) !important;
+    transition: all var(--hovering-speed) !important;
+}
+#identity-permission-box{
+     border-radius:var(--button-corner-rounding) !important;
+     transition: var(--animation-speed) !important;
+     position:  relative !important;
+     left: 0px !important;
+}
+#reader-mode-button:hover {
+  border-radius: var(--button-corner-rounding) !important;
+}
+toolbarbutton.bookmark-item{
+    margin-right: 10px !important;
+}
+#PlacesToolbarItems > toolbarbutton{
+    margin-right: 0px !important;
+}
+#reload-button > .toolbarbutton-icon{
+    margin-top: 1px !important;
+}
+#stop-button > .toolbarbutton-icon{
+    margin-top: 1px !important;
+}
+#urlbar-zoom-button{
+    background: var(--toolbarbutton-hover-background) !important;
+}
+#urlbar-zoom-button .toolbarbutton-text{
+    color: black;
+}
+#tracking-protection-icon-box{
+    color:initial !important;
+}
+#identity-box{
+    color:initial !important;
+}
+.identity-box-button:hover:not([open="true"]), #tracking-protection-icon-container:hover:not([open="true"]) {
+  background-color: var(--toolbarbutton-hover-mozilla-button) !important;
+  color: var(--urlbar-box-hover-text-color);
+}
+#tracking-protection-icon-container:hover{
+     border-radius:var(--button-corner-rounding) !important;
+     transition:all var(--animation-speed) !important;
+}
+
+.urlbar-page-action:not([disabled]):hover, #urlbar-go-button:hover, .search-go-button:hover {
+  background-color: var(--toolbarbutton-hover-mozilla-button) !important;
+  color: var(--urlbar-box-hover-text-color);
+}
+#urlbar-go-button {
+  border-radius: var(--button-corner-rounding) !important;
+}
+.bookmark-item {
+    padding-left: 7px !important;
+    padding-right: 7px !important;
+    margin-right: 0px !important;
+}
+.bookmark-item menupopup menuitem {
+    margin-right: 11px !important;
+}
+#star-button-box {
+  height: initial !important;
+  width: initial !important;
+  padding: initial !important;
+}
+#pageAction-urlbar-_testpilot-containers {
+  height: initial !important;
+  width: initial !important;
+  padding: initial !important;
+  border-radius: 5px !important;
+}
+#pageAction-urlbar-canvasblocker_kkapsner_de {
+  width: initial !important;
+  height: initial !important;
+  padding: initial !important;
+  border-radius:var(--button-corner-rounding)  !important;
+  opacity: 0;
+}
+#urlbar:hover #pageAction-urlbar-canvasblocker_kkapsner_de{
+    transition: all var(--animation-speed) !important;
+    opacity: 1;
+}
+#urlbar[focused] #pageAction-urlbar-canvasblocker_kkapsner_de{
+    opacity:1;
+}
+
+#star-button-box:hover{
+    transition:  all var(--hovering-speed) !important;
+    border-radius:var(--button-corner-rounding) !important; 
+    background-color:var(--toolbarbutton-hover-mozilla-button) !important;
+}
+#identity-icon-box:hover{
+    transition:   all var(--hovering-speed) !important;
+    border-radius:var(--button-corner-rounding) !important;
+}
+#identity-icon-box[open] {
+  background-color: var(--toolbarbutton-focus-background) !important;
+  border-radius: var(--button-corner-rounding) !important;
+}
+#identity-icon-box[open]:hover{
+    background-color:var(--toolbarbutton-hover-mozilla-button) !important;
+    border-radius: var(--button-corner-rounding) !important;
+}
+#identity-permission-box[open]{
+    background-color: var(--toolbarbutton-focus-background) !important;
+}
+#identity-permission-box[open]:hover{
+     background-color:var(--toolbarbutton-hover-mozilla-button) !important;
+}
+
+toolbarbutton#library-button.toolbarbutton-1{
+    padding-left:23px !important;
+}
+#downloads-button[open="true"]:hover{
+    background: var(--toolbarbutton-focus-background) !important;
+}
+#library-button[open="true"] {
+ background-color:var(--toolbarbutton-focus-background) !important;
+}
+#library-button[open="true"]:hover {
+  background: var(--toolbarbutton-focus-background) !important;
+}
+#downloads-button[open="true"] {
+    background-color:var(--toolbarbutton-focus-background) !important;
+}
+#downloadsHistory {
+  border-radius: var(--button-corner-rounding) !important;
+}
+#PanelUI-menu-button[open="true"]{
+    background-color: var(--toolbarbutton-focus-background) !important;
+}
+#PanelUI-menu-button[open="true"]:hover{
+    background: var(--toolbarbutton-focus-background) !important;
+}
+#urlbar-background {
+    background-color: var(--transparent-color) !important;
+    border: none !important;
+    box-shadow: none !important;
+}
+
+#urlbar[breakout-extend] {
+    top: 4px !important;
+    left: 0px !important;
+    padding: 0px 0px 0px 0px !important;
+    height: auto !important;
+    width: 100% !important;
+}
+#urlbar[breakout]{
+    width:99.5% !important;
+    transition:background-color 0.25s ease !important;
+}
+
+#urlbar[breakout][breakout-extend] > #urlbar-input-container {
+    /*height: var(--urlbar-toolbar-height) !important;*/
+    padding-block: 0px !important;
+    padding-inline: 0px !important;
+    padding-bottom: 6px !important;
+    margin-bottom: -5px !important;
+    margin-top: -1px !important;
+}
+#urlbar {
+    border-radius: calc(1px + var(--button-corner-rounding)) !important;
+    border: none !important;
+}
+#urlbar-input:not(:focus):hover{
+    margin-left:2px !important;
+    border-radius: var(--button-corner-rounding) !important;
+    background: var(--toolbarbutton-hover-background) !important;
+    transition: var(--animation-speed) !important;
+}
+.urlbarView {
+    width: 100% !important;
+    margin-inline: 0px !important;
+    box-shadow: 0px 5px 15px -7px black !important;
+    border-radius: 0px 0px var(--menu-corner-rounding) var(--menu-corner-rounding) !important;
+    border: none !important;
+    padding-top: 0px !important;
+}
+span.urlbarView-url {
+  color: var(--url-color-urlbarView) !important;
+  line-height: 1.4;
+  margin-left: 0.5%;
+}
+.urlbarView-body-inner {
+    border:none !important;    
+    padding-left:15px;
+    background-color: var(--toolbar-bgcolor) !important;
+}
+.urlbarView-body-inner .urlbarView-row{
+    padding-right:30px;
+}
+
+#tracking-protection-icon-container[open="true"]{
+    background:rgb(118, 123, 134) !important;
+}
+.urlbarView-row {
+  background-color: var(--transparent-color) !important;
+  color: black !important;
+}
+.urlbarView-row-inner {
+  border-radius: var(--menu-corner-rounding) !important;
+  transition:var(--animation-speed) !important;
+}
+.urlbarView-row-inner[aria-selected] {
+  background: var(--toolbarbutton-focus-background) !important;
+}
+#urlbar .searchbar-engine-one-off-item[selected="true"]{
+    background: var(--toolbarbutton-focus-background) !important;
+}
+
+.search-one-offs {
+    background-color: var(--toolbar-bgcolor) !important;
+    padding-left:15px;
+    padding-right:10px;
+    color:white !important;
+}
+.search-one-offs button:hover{
+   transition:var(--animation-speed) !important;
+   border-radius:var(--button-corner-rounding) !important;
+   color:white !important;
+}
+
+hbox.urlbar-page-action{
+    padding:0px !important;
+}
+
+#tracking-protection-icon-container {
+    border-inline-end: none !important;
+}
+
+#pageActionSeparator {
+    display: none !important;
+}
+
+.urlbar-icon, #userContext-indicator, #userContext-label {
+    fill: transparent !important;
+    background-color: var(--transparent-color) !important;
+    color: var(--transparent-color) !important;
+    transition: var(--animation-speed) !important;
+}
+
+
+#urlbar:hover .urlbar-icon,
+#urlbar:active .urlbar-icon, 
+#urlbar[focused] .urlbar-icon {
+    fill: var(--toolbar-color) !important;
+}
+
+.urlbar-page-action[open] {
+    background-color: var(--toolbarbutton-focus-background) !important;
+    fill: var(--toolbar-color) !important;
+    opacity: 1 !important;
+}
+
+.urlbar-page-action[open]:hover {
+    background-color: var(--toolbarbutton-focus-background) !important;
+    fill: var(--toolbar-color) !important;
+    opacity: 1 !important;
+}
+
+.urlbar-page-action[open] .urlbar-icon {
+    fill: var(--toolbar-color) !important;
+     opacity: 1 !important;
+}
+
+.urlbar-scheme {
+    padding-bottom: 11px !important;
+}
+
+
+#urlbar-container {
+    margin-left: -1px !important;
+    margin-right: -1px !important;
+}
+.urlbar-input-box {
+    padding: 0px 5px !important;
+}
+
+#urlbar {
+    background-color: var(--transparent-color) !important;
+    color: var(--lwt-toolbar-field-color, black) !important;
+}
+#urlbar-go-button:hover{
+    background-color: var(--toolbarbutton-hover-background) !important;
+    border-radius: var(--button-corner-rounding);
+}
+.urlbar-input-box input{
+    padding-left: 5px !important;
+}
+#urlbar:not(.hidden-focus)[focused=""]{
+    animation: crunch var(--animation-speed) ease-out forwards !important;
+}
+@keyframes crunch{
+    0% {background: linear-gradient(to left, transparent,transparent,transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent,transparent,transparent)}
+    25% {background: linear-gradient(to left, transparent,transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent,transparent)}
+    50% {background: linear-gradient(to left, transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent)}
+    75% {background: linear-gradient(to left, transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent)}
+    100% {background: linear-gradient(to left, var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background))}
+}
+@keyframes crunchOnFade{
+    0% {background: linear-gradient(to left, var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background))}
+    12% {background: linear-gradient(to left, transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent)}
+    25% {background: linear-gradient(to left, transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent)}
+    38% {background: linear-gradient(to left, transparent,transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent,transparent)}
+    50% {background: linear-gradient(to left, transparent,transparent,transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent,transparent,transparent)}
+    66% {background: linear-gradient(to left, transparent,transparent,transparent,transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent,transparent,transparent,transparent)}
+    75% {background: linear-gradient(to left, transparent,transparent,transparent,transparent,transparent,transparent,var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),var(--toolbarbutton-hover-background),transparent,transparent,transparent,transparent,transparent,transparent)}
+    83% {background: linear-gradient(to left, transparent,transparent,transparent,transparent,transparent,transparent,transparent,var(--toolbarbutton-hover-background),transparent,transparent,transparent,transparent,transparent,transparent,transparent)}
+    100% {background: linear-gradient(to left, transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent,transparent)}
+}
+/*Section for download rules*/
+#downloadsHistory{
+    padding-bottom: 10px !important;
+    padding-top: 10px !important;
+    margin-left: 0px !important;
+    margin-right: 0px !important;
+}
+
+/**/
+#pocket-button {
+    padding-bottom: 4px !important;
+}
+
+.urlbar-icon-wrapper > .urlbar-icon:hover {
+    background-color: var(--transparent-color) !important;
+}
+
+.urlbar-icon-wrapper {
+    background-color: var(--transparent-color) !important;
+    transition: background-color var(--animation-speed) !important;
+}
+#notification-popup-box {
+  position: relative !important;
+  padding-left:2px !important;
+  padding-right:2px !important;
+  height: initial !important;
+  left: 0px !important;
+  transition: all var(--hovering-speed) !important;
+  border-radius:var(--button-corner-rounding) !important;
+}
+
+#identity-icon-box {
+  border-radius: 5px !important;
+}
+
+
+#identity-permission-box[open="true"], #identity-permission-box[hasPermissions], #identity-permission-box[hasSharingIcon] {
+  display: -webkit-inline-box;
+  margin-right: 1px !important;
+  margin-left: 1px !important;
+  border-radius:var(--button-corner-rounding) !important;
+}
+#tracking-protection-icon-container[open="true"]{
+    background:var(--toolbarbutton-focus-background) !important;
+    border-radius:var(--button-corner-rounding) !important;
+}
+#tracking-protection-icon-container[open="true"]:hover{
+    background: rgb(115, 118, 124) !important;
+    border-radius:var(--button-corner-rounding) !important;
+}
+
+#notification-popup-box:hover{
+    border-radius:var(--button-corner-rounding) !important;
+    background-color: var(--toolbarbutton-hover-mozilla-button) !important; 
+}
+.identity-box-button:hover:active, .identity-box-button[open="true"], #tracking-protection-icon-container:hover:active, #tracking-protection-icon-container[open="true"] {
+    background-color: var(--toolbarbutton-hover-mozilla-button);
+    border-radius: var(--button-corner-rounding) !important;
+}
+
+#identity-box[pageproxystate="valid"].notSecureText > .identity-box-button, #identity-box[pageproxystate="valid"].chromeUI > .identity-box-button, #identity-box[pageproxystate="valid"].extensionPage > .identity-box-button, #urlbar-label-box {
+    border-radius:var(--button-corner-rounding) !important;
+}
+
+#identity-box:active,
+#tracking-protection-icon-container:active,
+.urlbar-icon:active,
+.urlbar-icon-wrapper:active,
+[anonid=urlbar-go-button]:active {
+    /*background-color: var(--toolbarbutton-focus-background) !important;*/
+}
+
+.urlbar-input-box, 
+#identity-box,
+#tracking-protection-icon-container,
+[anonid=urlbar-go-button],
+#urlbar {
+    transition: background-color var(--hovering-speed) !important;
+    animation: crunchOnFade var(--animation-speed) ease-out forwards !important;
+}
+#tracking-protection-icon,
+#identity-box image {
+    transition: fill-opacity var(--animation-speed) !important;
+}
+[lwthemetextcolor="dark"] .urlbarView-body-outer {
+    background-color: #f5f6f7 !important;
+    color: var(--toolbar-color) !important;
+}
+
+.downloadsPanelFooterButton:hover {
+    outline: none !important;
+}
+
+#urlbar[focused] #pageAction-urlbar-_testpilot-containers{
+    opacity:1 !important;
+}
+#urlbar[focused] #userContext-icons{
+    opacity:1 !important;
+}
+#urlbar:not(focused) #tracking-protection-icon-container{
+    opacity: 0 !important;
+}
+#urlbar:not(focused) #tracking-protection-icon-container[open]{
+    opacity: 1 !important;
+}
+#urlbar[focused] #tracking-protection-icon-container{
+    opacity: 1 !important;
+}
+#urlbar:not(focused) #identity-box{
+    opacity: 0 !important;
+}
+#urlbar:not(focused) #identity-box:has(.identity-box-button[open]){
+    opacity: 1 !important;
+}
+#urlbar[focused] #identity-box{
+    opacity: 1 !important;
+}
+
+#userContext-icons{
+  opacity:0;
+  margin:auto 3px!important;
+  border-radius:2px!important;
+  padding:0 2px 0 5px!important;
+  transition: var(--hovering-speed) all !important;
+}
+#urlbar:hover #userContext-icons {
+    opacity:1;
+    -moz-transition: var(--animation-speed) !important;
+}
+#urlbar:hover #pageAction-urlbar-_testpilot-containers{
+    opacity:1;
+    -moz-transition: var(--animation-speed) !important;
+    transition: all var(--hovering-speed) !important;
+}
+#urlbar:hover #tracking-protection-icon-container{
+    opacity: 1 !important;
+    -moz-transition: var(--animation-speed) !important;
+    transition: all var(--hovering-speed) !important;
+}
+#urlbar:hover #identity-box{
+    opacity: 1 !important;
+    -moz-transition: var(--animation-speed) !important;
+    transition: all var(--hovering-speed) !important;
+}
+#pageAction-urlbar-_testpilot-containers{
+    opacity:0;
+    -moz-transition: var(--animation-speed) !important;
+}
+#pageAction-urlbar-_testpilot-containers:hover{
+    opacity:1;
+    background-color: var(--toolbarbutton-hover-mozilla-button) !important;
+    border-radius: var(--button-corner-rounding) !important;
+}
+#pageAction-urlbar-_testpilot-containers.urlbar-page-action[focused]{
+    opacity:1 !important;
+}
+
+
+#userContext-icons:hover{
+  opacity:1;
+  border-radius: var(--button-corner-rounding) !important;
+  background:var(--identity-tab-color)!important;
+  -moz-transition: var(--animation-speed) !important;  
+}
+.urlbar-input-container:hover{
+    opacity:1;
+    border-radius: var(--button-corner-rounding) !important;
+    -moz-transition:var(--animation-speed) !important;
+}
+.urlbar-input{
+    color:initial !important;
+    text-align: initial !important;
+}
+.urlbar-input-box{
+    direction: initial !important;
+}
+.urlbar-input-container{
+    padding: initial !important;
+}
+.urlbar-go-button:hover{
+    background: var(--toolbarbutton-hover-background) !important;
+    transition: var(--animation-speed) !important;
+}
+#urlbar[breakout][breakout-extend] {
+  & > .urlbar-input-container {
+    height: 36px !important;
+    padding-block: initial;
+    padding-inline: initial;
+  }
+}
+#urlbar-label-switchtab{
+    color:white !important;
+}
+#urlbar-search-mode-indicator{
+    color:white !important;
+}
+#urlbar-input-container{
+    color:white !important;   
+    padding: 0px !important;
+}
+#urlbar-background{
+    border-radius: var(--button-corner-rounding) !important;
+    display: none !important;
+}
+.urlbarView-row-inner{
+    font:white !important;
+}
+.urlbarView-row-inner:hover{
+    background:var(--toolbarbutton-hover-background) !important;
+    color:white !important;
+}
+
+
+.urlbarView-results{
+    color:white;
+}
+
+#reader-mode-button-icon.urlbar-icon:hover{
+ background:var(--toolbarbutton-hover-background) !important;   
+ animation-delay:var(--animation-speed) !important;
+}
+#reader-mode-button-icon.urlbar-icon[focused]{
+    opacity:1 !important;
+}
+#reader-mode-button image{
+    max-width:200% !important;
+    height:auto !important;
+}
+#reader-mode-button {
+  width: initial !important;
+  height: initial !important;
+}
+#userContext-label{
+  color:#fff!important;
+  margin: 6px !important;
+}
+#userContext-indicator {
+  fill:#fff!important;
+  margin-right:2px!important;
+}
+#userContext-indicator[data-identity-icon="circle"] {
+  display:none!important;
+}
+/*Linear gradient trick for newbies like me*/
+.tabbrowser-tab[usercontextid] > .tab-stack > .tab-background > .tab-context-line {
+  background: var(--identity-icon-color) !important;
+  height: 3.5px !important;
+  border-radius: 2px !important;
+}

--- a/whitemode/userChrome.css
+++ b/whitemode/userChrome.css
@@ -1,0 +1,82 @@
+@import url("quietTab.css");
+@import url("quietUrlbar.css");
+@import url("quietExtensions.css");
+@import url("quietMenus.css");
+@import url("quietContexts.css");
+/*
+
+Quietfox Reborn v130
+
+https://github.com/TheGITofTeo997/quietfoxReborn
+
+Thanks for using our file!
+
+Edit by: Krokko&Teo
+*/
+
+* { 
+/* -------------------- 🎨 Customization 🎨 -------------------- */
+    --tab-corner-rounding: 7px;
+    --button-corner-rounding: 7px;
+    --menu-item-height: 35px;
+    --animation-speed: 0.15s;
+    --hovering-speed:300ms;
+    --menu-corner-rounding: 7px;
+    --icon-border-rounding: 10px;
+    --button-hovered-corner-rounding:11px;
+    --toolbarbutton-hover-background: rgba(127, 127, 127, 0.5);
+    --toolbarbutton-hover-mozilla-button: rgb(115, 118, 124);
+    --toolbarbutton-focus-background: rgb(115, 118, 124);
+    --url-color-urlbarView: rgb(184, 200, 255);
+    --toolbarbutton-dragover:rgb(93, 97, 105);
+    --container-context-line-speed-animation:0.6s;
+    --icons-burger-menu-fill-color:black;
+	--transparent-color:transparent;
+}
+
+/*Context line colors, you can edit this part if you want to change your container line colors*/
+.identity-color-blue {
+  --identity-tab-color: #37adff !important; 
+  --identity-icon-color: linear-gradient(to right,#375cff,#37adff) !important;
+}
+
+.identity-color-turquoise {
+  --identity-tab-color: #00c79a !important;
+  --identity-icon-color: linear-gradient(to left,#00c79a,#00795e) !important;
+}
+
+.identity-color-green {
+  --identity-tab-color: #51cd00 !important;
+  --identity-icon-color: linear-gradient(to left,#51cd00,#2c7300) !important; 
+}
+
+.identity-color-yellow {
+  --identity-tab-color: #ffcb00 !important;
+  --identity-icon-color: linear-gradient(to left,#ffcb00,#7e6500) !important;
+}
+
+.identity-color-orange {
+  --identity-tab-color: #ff9f00 !important;
+  --identity-icon-color: linear-gradient(to right, #ff4800, #ffa000) !important;
+}
+
+.identity-color-red {
+  --identity-tab-color: #ff613d !important;
+  --identity-icon-color: linear-gradient(to left,#ff613d,#7e2f1d) !important;
+}
+
+.identity-color-pink {
+  --identity-tab-color: #ff4bda !important;
+  --identity-icon-color: linear-gradient(to left,#ff4bda,#651d47) !important;
+}
+
+.identity-color-purple {
+  --identity-tab-color: #af51f5 !important;
+  --identity-icon-color: linear-gradient(to left,#af51f5,#512274) !important; 
+}
+
+/* -------------------- 🎨END Customization 🎨 -------------------- */
+
+@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+
+ Bottom corner rounding for tabs, Remove this section if your tab bottom corners look bad 


### PR DESCRIPTION
Hello there, I'm not sure how many people uses white mode, as dark mode has been starting to be more widely utilized, but I've just modified the CSS to suit with elements from white mode
![image](https://github.com/user-attachments/assets/ecc5344a-302c-40db-bdd3-c4e9a42e7e91)
I've also separated White Mode in a separate folder. I suppose you wanna use it just as a reference, so you merge it with the final chrome folder; but feel free to make it as a separate release, if you want to

### *=/=/=/=/=If I already made a second pull request, ignore everything mentioned below =/=/=/=/=*

Unfortunately I couldn't find anywhere about the URL color and hovertab.
I had to use **black** for the text color instead of the planned #454545 (despite not being taken at QuietFox's original repo) so the texts are atleast legible
![image](https://github.com/user-attachments/assets/b124464c-af1f-4610-9712-70e734c70aed)
For the colors, I've got a Firefox Color theme that fixes it, despite creating a line on the top ![image](https://github.com/user-attachments/assets/b1331464-c5d9-4447-bf03-5dbb6bacbcaf)

https://color.firefox.com/?theme=XQAAAAItAQAAAAAAAABBqYhm849SCia2CaaEGccwS-xMDPsqvOJTBAF6EJDWcx9sS_Bi3JZIpDRYYZEIcGfgGdAvS2aJX1zVIBQNTNOhti_WJjvze3wkgmzU00djhQZeVcNgTbpoYeWc-6CxKg0qk31FK3WCcc_ZyEWMkaobqU5WF3mZe28MOjOyXBPloFb7hHU0VmgtDQ8-2OoFS7MAl_Fr0slrIpUkkaQvn9Lnk9Q-6iDnot_DjmyRP2jDItNdXyD9p_4N9jvxDk_XGwvLwmxacSP_-R9psQ


**Which parameters contains these related modifications?** 

